### PR TITLE
WIP: Use Hugo modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.hugo_build.lock
+resources

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+module:
+  imports:
+  - path: github.com/google/docsy
+  - path: github.com/google/docsy/dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/acend/docsy-plus
+
+go 1.17
+
+require (
+	github.com/google/docsy/dependencies v0.2.0-pre // indirect
+	github.com/google/docsy v0.2.0-pre // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/acend/docsy-plus
 go 1.17
 
 require (
-	github.com/google/docsy/dependencies v0.2.0-pre // indirect
 	github.com/google/docsy v0.2.0-pre // indirect
+ 	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
+	github.com/google/docsy/dependencies v0.2.0-pre // indirect
+	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.1.0 h1:CFlYmjOf9Wz86cgmXYK701KePcuYMHBnk+Ud4X2QIyo=
-github.com/google/docsy v0.1.0/go.mod h1:alhAPKceHP14eqO+nJEhYehHeNcPKV8QnduoauTBZhs=
-github.com/google/docsy v0.2.0-pre h1:HVOooPDnwA/gL0F4tVrylSiJqMczPhvB8ZyCz5fhxjs=
+github.com/google/docsy v0.2.0-pre h1:vQc8vUD6ArSKCZM2BA1tckwhHSA5Vi3GwqtdywQiAaU=
 github.com/google/docsy v0.2.0-pre/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
 github.com/google/docsy/dependencies v0.2.0-pre h1:rr4XfnpvqIEuG71jpo6p7e1/kxvkHQJNh7ewqWpzJzg=
 github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.1.0 h1:CFlYmjOf9Wz86cgmXYK701KePcuYMHBnk+Ud4X2QIyo=
+github.com/google/docsy v0.1.0/go.mod h1:alhAPKceHP14eqO+nJEhYehHeNcPKV8QnduoauTBZhs=
+github.com/google/docsy v0.2.0-pre h1:HVOooPDnwA/gL0F4tVrylSiJqMczPhvB8ZyCz5fhxjs=
+github.com/google/docsy v0.2.0-pre/go.mod h1:yuKLZHMX5CKiLUH55+ePFJaYnoSwUVVffNareaOGQYo=
+github.com/google/docsy/dependencies v0.2.0-pre h1:rr4XfnpvqIEuG71jpo6p7e1/kxvkHQJNh7ewqWpzJzg=
+github.com/google/docsy/dependencies v0.2.0-pre/go.mod h1:oPdn05sNt61uT6K+LqNRhYq1jeqrsbbQMDXkPdPscmA=
+github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
The following PRs have added Hugo Modules support to Docsy:
https://github.com/google/docsy/pull/871
https://github.com/google/docsy/pull/802

I would wait until v0.2.0 is released.

To use the the docsy-plus module the following can be added into the config:
```
theme = ["github.com/acend/docsy-plus"]
```

It might even make sense to have `docsy-puzzle` and `docsy-acend` manage the `docsy-plus` theme.

See https://gohugo.io/hugo-modules/use-modules/ for more information on how to use Hugo Modules.

I had some problems with Module versions. The required module versions from https://github.com/google/docsy/blob/master/go.mod must be added to `go.mod` within this repository. Running `hugo mod tidy` should add these automatically.