### PR TITLE
Add automatic section numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -160,3 +160,57 @@ The Mode Switcher will automatically open detail elements, with `mode-switcher="
 some content
 {{% /details %}}
 ```
+
+## Automatic Section Numbers
+
+This feature can be enabled by adding the following configuration in the `params` section in your `config.toml`
+
+```yaml
+automaticSectionNumbers = true
+```
+
+All Sections under docs will then have the section number prefixed to the title.
+
+### Tasks
+
+The `task` shortcode can be used on pages to have an automatic numbering of the task chapters.
+
+The following page
+
+```markdown
+---
+title: "First Page"
+weight: 10
+
+---
+
+## Title
+
+### {{% task %}} Create a File with the Name
+
+
+### {{% task %}} Create a second File with the Name
+
+```
+
+will render into:
+
+```markdown
+
+## Title
+
+### Task 1.1: Create a File with the Name
+
+
+### Task 1.2: Create a second File with the Name
+```
+
+Each time the `task` shortcode is inserted it increases the subchapter heading by one.
+
+### Link Shortcode
+
+Can be used like `ref`, but also inserts the full link with numbering and title.
+
+```markdown
+{{< link "/content/en/docs/01/_index.md" >}}
+```

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -8,16 +8,7 @@
     {{- end -}}
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+ 		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,4 +1,4 @@
-{{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
+{{ define "main" }}
 <div class="td-content">
     {{- if site.Params.automaticSectionNumbers -}}
     {{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
@@ -6,7 +6,7 @@
     {{- else -}}
 	<h1>{{ .Title }}</h1>
     {{- end -}}
-	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+  {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ $context := . }}
 		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
@@ -23,14 +23,16 @@
 		{{ end }}
 	</header>
 	{{ .Content }}
-    <div class="text-muted mt-5 pt-3">{{ partial "prevnextlinks.html" . }}</div>
+        {{ partial "section-index.html" . }}
+        <div>{{ partial "prevnextlinks.html" . }}</div>
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.Params.DisqusShortname) }}
+	{{ if (.Site.DisqusShortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
 	{{ partial "page-meta-lastmod.html" . }}
 </div>
+{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,16 +8,7 @@
     {{- end -}}
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+ 		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,4 +1,5 @@
 {{/* Copied and adapted from themes/docsy/layouts/partials/section-index.html */}}
+{{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
 <div class="section-index">
     {{ $parent := .Page }}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
@@ -12,28 +13,29 @@
     {{/* If simple_list is true we show a bulleted list of subpages */}}
         <ul>
             {{ range $pages }}
-                {{ $onlyWhen := default "base" .Params.onlyWhen }}
-                {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
                 {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
-                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
-                {{ end }}
+                {{- $title := .Title -}}
+                {{- if site.Params.automaticSectionNumbers -}}
+                    {{- $title = printf "%s %s" ($sectionnumbers.Get .File.Path) .Title -}}
+                {{- end -}}
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a></li>
             {{ end }}
         </ul>
     {{ else }}
     {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
     <hr class="panel-line">
         {{ range $pages }}
-            {{ $onlyWhen := default "base" .Params.onlyWhen }}
-            {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
             {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
-                <div class="entry">
-                    <h5>
-                        <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
-                    </h5>
-                    <p>{{ .Description | markdownify }}</p>
-                </div>
-            {{ end }}
+            <div class="entry">
+                <h5>
+                    {{- $title := .Title -}}
+                    {{- if site.Params.automaticSectionNumbers -}}
+                        {{- $title = printf "%s %s" ($sectionnumbers.Get .File.Path) .Title -}}
+                    {{- end -}}
+                    <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a>
+                </h5>
+                <p>{{ .Description | markdownify }}</p>
+            </div>
         {{ end }}
     {{ end }}
 </div>
-<div>{{ partial "prevnextlinks.html" . }}</div>

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -1,0 +1,27 @@
+{{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+{{ $data := newScratch }}
+{{ $data = partial "sectionnumber-nested" (dict "page" . "section" $navRoot "data" $data) }}
+{{ return $data }}
+
+{{ define "partials/sectionnumber-nested" -}}
+{{ $s := .section }}
+{{ $p := .page }}
+{{ $d := .data }}
+{{ $sectionNr := .sectionNr | default "" }}
+{{ $pages := (union .section.Pages $s.Sections).ByWeight -}}
+{{ $withChild := gt (len $pages) 0 -}}
+  {{ $sectionNr }}{{ $s }}
+  {{ .data.Set $s.File.Path $sectionNr }}
+  {{- if $withChild }}
+    {{ range $index, $item := $pages -}}
+      {{ $onlyWhen := default "base" $item.Params.onlyWhen }}
+      {{ if and (in site.Params.enabledModule $onlyWhen) (not (in site.Params.enabledModule $item.Params.onlyWhenNot)) }}
+      {{ if (not (and (eq $s site.Home) (eq $item.Params.toc_root true))) -}}
+        {{ $newSectionNr := printf "%s%d." $sectionNr (add $index 1) }}
+        {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" $item "sectionNr" $newSectionNr "data" $d) }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{ return $d }}
+{{- end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -37,6 +37,11 @@
 {{ define "section-tree-nav-section" -}}
 {{ $s := .section -}}
 {{ $p := .page -}}
+{{ $sectionnumber := "" }}
+{{ if site.Params.automaticSectionNumbers }}
+  {{ $sectionnumbers := partialCached "sectionnumber.html" .page }}
+  {{ $sectionnumber = $sectionnumbers.Get .section.File.Path }}
+{{ end }}
 {{ $shouldDelayActive := .shouldDelayActive -}}
 {{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
 {{ $treeRoot := cond (eq .ulNr 0) true false -}}
@@ -54,9 +59,9 @@
 <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
-  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ with $sectionnumber }}{{ . }} {{ end }}{{ $s.LinkTitle }}</span></a></label>
   {{ else -}}
-  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ with $sectionnumber }}{{ . }} {{ end }}{{ $s.LinkTitle }}</span></a>
   {{- end }}
   {{- if $withChild }}
   {{- $ulNr := add $ulNr 1 }}

--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -1,0 +1,9 @@
+{{ $ref := .Get 0 }}
+{{- $sectionnumber := "" -}}
+{{ with site.GetPage $ref }}
+{{- if site.Params.automaticSectionNumbers -}}
+{{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
+{{- $sectionnumber = $sectionnumbers.Get .File.Path -}}
+{{- end -}}
+<a href="{{ .Permalink }}">{{ $sectionnumber }} {{ .Title }}</a>
+{{ end }}

--- a/layouts/shortcodes/task.html
+++ b/layouts/shortcodes/task.html
@@ -1,0 +1,11 @@
+{{- .Page.Scratch.Add "task" 1 -}}
+{{- if site.Params.automaticSectionNumbers -}}
+{{- $sectionnumbers := partialCached "sectionnumber.html" .Page -}}
+Task {{ $sectionnumbers.Get .Page.File.Path }}{{ .Page.Scratch.Get "task" }}:
+{{- else -}}
+{{- with .Page.Params.sectionnumber -}}
+Task {{ . }}.{{ $.Page.Scratch.Get "task" }}:
+{{- else -}}
+{{- errorf "Either automaticSectionNumbers or sectionnumber must be set in %q" .Page.Path -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
TODO: description in README

Enable by setting `automaticSectionNumbers = true` in the `config.toml`

Shortcodes:
- `task`: Adds `Task X.X:` (mainly for in headings)
- `link`: Can be used like `ref`, but also inserts the full link with numbering and title.