### PR TITLE
Remove trailing whitespace from link shortcode

### DIFF
--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -1,9 +1,9 @@
-{{ $ref := .Get 0 }}
+{{- $ref := .Get 0 -}}
 {{- $sectionnumber := "" -}}
-{{ with site.GetPage $ref }}
-{{- if site.Params.automaticSectionNumbers -}}
-{{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
-{{- $sectionnumber = $sectionnumbers.Get .File.Path -}}
-{{- end -}}
+{{- with site.GetPage $ref -}}
+{{-   if site.Params.automaticSectionNumbers -}}
+{{-     $sectionnumbers := partialCached "sectionnumber.html" . -}}
+{{-     $sectionnumber = $sectionnumbers.Get .File.Path -}}
+{{-   end -}}
 <a href="{{ .Permalink }}">{{ $sectionnumber }} {{ .Title }}</a>
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
The main change is line 9: `{{- end -}}` so that we can use the shortcode inline without a newline being inserted. 