### PR TITLE
fix section-index rendering for onlyWhen/onlyWhenNot filtering cases

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -16,7 +16,7 @@
     {{/* Get all pages where onlyWhenNot is set */}}
     {{ $pagesOnlyWhenNot := where $pages ".Params.onlyWhenNot" "in" site.Params.enabledModule }}
     {{/* Get all pages where onlyWhenNot is nil and combine them with the above */}}
-    {{ $pages = complement $pagesOnlyWhenNot (where $pages ".Params.onlyWhenNot" "==" nil) }}
+    {{ $pages = complement $pagesOnlyWhenNot $pages }}
 
     {{/* Sort the pages again */}}
     {{ $pages = $pages.ByWeight }}


### PR DESCRIPTION
This fixes the section-index when using onlyWhenNot on pages.
Befor this, the section-index only showed the pages from the techlab variant even when not in techlab environment

This is how it looks now:

![Screenshot from 2022-07-15 13-25-27](https://user-images.githubusercontent.com/3875381/179214270-27f4b481-34f6-4fe6-bdee-a212884f44b5.png)

With environment = techlab
![Screenshot from 2022-07-15 13-25-05](https://user-images.githubusercontent.com/3875381/179214263-12581cbd-9fa2-4404-bdf6-111b6a830dac.png)

This was before the fix, not in environment = techlab but section-index only showed the pages from environment = techlab

![Screenshot from 2022-07-15 13-28-12](https://user-images.githubusercontent.com/3875381/179214686-b84b2bb3-b7ba-4da4-a378-8e670c694e12.png)

