### PR TITLE
Fix automatic section numbering

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,7 +1,7 @@
 {{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
 <div class="td-content">
     {{- if site.Params.automaticSectionNumbers -}}
-    {{- $sectionnumbers := partialCached "sectionnumber.html" . -}}
+    {{- $sectionnumbers := partial "sectionnumber.html" . -}}
     <h1>{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</h1>
     {{- else -}}
 	<h1>{{ .Title }}</h1>

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -1,29 +1,32 @@
 {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
-{{ $data := newScratch }}
-{{ $data = partial "sectionnumber-nested" (dict "page" . "section" $navRoot "data" $data) }}
+{{ $data := $navRoot.Scratch }}
+{{/* partialCached does not work here. The Scratch is sometimes empty and only contains data when content is modified */}}
+{{/* Check if the current page was already evaluated */}}
+{{ if not ($data.Get .File.Path) }}
+    {{ $data = partial "sectionnumber-nested" (dict "page" . "section" $navRoot "data" $data) . $navRoot }}
+{{ end }}
 {{ return $data }}
 
 {{ define "partials/sectionnumber-nested" -}}
-{{ $s := .section }}
-{{ $p := .page }}
-{{ $d := .data }}
-{{ $sectionNr := .sectionNr | default "" }}
-{{ $pages := (union .section.Pages $s.Sections).ByWeight -}}
-{{ $withChild := gt (len $pages) 0 -}}
-  {{ $sectionNr }}{{ $s }}
+  {{ $s := .section }}
+  {{ $p := .page }}
+  {{ $d := .data }}
+  {{ $sectionNr := .sectionNr | default "" }}
   {{ .data.Set $s.File.Path $sectionNr }}
+  {{ $pages := (union $s.Pages $s.Sections).ByWeight -}}
+  {{ $withChild := gt (len $pages) 0 -}}
   {{- if $withChild }}
     {{ $count := 0 }}
     {{ range $pages -}}
       {{ $onlyWhen := default "base" .Params.onlyWhen }}
       {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
-      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
-        {{ $count = add $count 1 }}
-        {{ $newSectionNr := printf "%s%d." $sectionNr $count }}
-        {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) }}
-      {{- end }}
-      {{- end }}
+        {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+          {{ $count = add $count 1 }}
+          {{ $newSectionNr := printf "%s%d." $sectionNr $count }}
+          {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) }}
+        {{- end }}
       {{- end }}
     {{- end }}
-    {{ return $d }}
+  {{- end }}
+  {{ return $d }}
 {{- end }}

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -13,12 +13,14 @@
   {{ $sectionNr }}{{ $s }}
   {{ .data.Set $s.File.Path $sectionNr }}
   {{- if $withChild }}
-    {{ range $index, $item := $pages -}}
-      {{ $onlyWhen := default "base" $item.Params.onlyWhen }}
-      {{ if and (in site.Params.enabledModule $onlyWhen) (not (in site.Params.enabledModule $item.Params.onlyWhenNot)) }}
-      {{ if (not (and (eq $s site.Home) (eq $item.Params.toc_root true))) -}}
-        {{ $newSectionNr := printf "%s%d." $sectionNr (add $index 1) }}
-        {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" $item "sectionNr" $newSectionNr "data" $d) }}
+    {{ $count := 0 }}
+    {{ range $pages -}}
+      {{ $onlyWhen := default "base" .Params.onlyWhen }}
+      {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
+      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+        {{ $count = add $count 1 }}
+        {{ $newSectionNr := printf "%s%d." $sectionNr $count }}
+        {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -39,7 +39,7 @@
 {{ $p := .page -}}
 {{ $sectionnumber := "" }}
 {{ if site.Params.automaticSectionNumbers }}
-  {{ $sectionnumbers := partialCached "sectionnumber.html" .page }}
+  {{ $sectionnumbers := partial "sectionnumber.html" .page }}
   {{ $sectionnumber = $sectionnumbers.Get .section.File.Path }}
 {{ end }}
 {{ $shouldDelayActive := .shouldDelayActive -}}


### PR DESCRIPTION
Rewrote the caching logic because `partialCached` did not work correctly.

The logic for excluding `onlyWhenNot` was faulty and used the `$index`. I now added a `$count` which is only incremented, when the page is rendered.