### PR TITLE
Removed whitespace trimming from highlight

### DIFF
--- a/layouts/shortcodes/readAndHighlight.html
+++ b/layouts/shortcodes/readAndHighlight.html
@@ -29,10 +29,10 @@ if the file is not found */}}
 
 {{ if fileExists ($.Scratch.Get "filepath") }}
   {{ if eq (.Get "code") "true" }}
-    {{ $hloptions := default "" ($.Get "highlight")  -}}
-    {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape) (.Get "lang") $hloptions -}}
+    {{ $hloptions := default "" ($.Get "highlight")  }}
+    {{ highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape) (.Get "lang") $hloptions }}
   {{ else }}
-    {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
+    {{ $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML }}
   {{ end }}
 {{ else }}
   {{errorf "The file %q was not found." .Path }}


### PR DESCRIPTION
{{- -}} trims whitespace from its contents. This is not necessary for our purposes, so let's remove it. Less complexity is more good.