### PR TITLE
Refactor automatic section numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ When using the Mode Switcher and including a nested Read and Highlight shortcode
 
 ## Automatic Section Numbers
 
-This feature can be enabled by adding the following configuration in the `params` section in your `config.toml`
+This feature can be enabled by adding the following configuration in your `hugo.toml`
 
 ```yaml
-automaticSectionNumbers = true
+[outputs]
+  home = ['html', 'sectionnumber', 'rss']
 ```
 
 All Sections under docs will then have the section number prefixed to the title.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,21 @@
 
+# This output format configuration is necessary
+# to ensure that Hugo sets the Page.Store values
+# for sectionnumbers before rendering the site.
+# There is an associated layout for the homepage.
+# This is a bit of a hack, but I don't know any better way.
+# To activate the sectionnumbers, add the format to your outputs.
+[outputFormats]
+  [outputFormats.sectionnumber]
+    mediaType = 'text/html'
+    notAlternative = true
+    weight = 1
+    # Make sure that the output does not override the homepage.
+    # Seems to only happen locally in some cases.
+    basename = ".ignore"
+  [outputFormats.html]
+    weight = 2
+
 [module]
   [module.hugoVersion]
     extended = true

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,11 +1,6 @@
 {{/* Copied and adapted from themes/docsy/layouts/_default/content.html */}}
 <div class="td-content">
-    {{- if site.Params.automaticSectionNumbers -}}
-    {{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-    <h1>{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</h1>
-    {{- else -}}
-	<h1>{{ .Title }}</h1>
-    {{- end -}}
+    <h1>{{ partial "sectionnumber" . }}{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,11 +1,6 @@
 {{ define "main" }}
 <div class="td-content">
-    {{- if site.Params.automaticSectionNumbers -}}
-    {{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-    <h1>{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</h1>
-    {{- else -}}
-	<h1>{{ .Title }}</h1>
-    {{- end -}}
+    <h1>{{ partial "sectionnumber" . }}{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}

--- a/layouts/index.sectionnumber.html
+++ b/layouts/index.sectionnumber.html
@@ -1,0 +1,16 @@
+{{- with site.GetPage "/docs" -}}
+      {{- partial "partials/sectionnumber-recursive" . -}}
+{{- end -}}
+
+{{ define "partials/sectionnumber-recursive" -}}
+  {{ $sectionnumber := "" }}
+  {{ with .Store.Get "sectionnumber" }}
+    {{ $sectionnumber = . }}
+  {{ end }}
+  {{ $count := 0 }}
+  {{ range .Pages }}
+    {{ $count = add $count 1 }}
+    {{ .Store.Set "sectionnumber" (fmt.Printf "%s%d." $sectionnumber $count) }}
+    {{ partial "partials/sectionnumber-recursive" . }}
+  {{ end }}
+{{- end }}

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,5 +1,4 @@
 {{/* Copied and adapted from themes/docsy/layouts/partials/section-index.html */}}
-{{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
 <div class="section-index">
     {{ $parent := .Page -}}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
@@ -31,10 +30,7 @@
             {{ range $pages -}}
                 {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
                 {{- $title := .Title -}}
-                {{- if site.Params.automaticSectionNumbers -}}
-                    {{- $title = printf "%s %s" ($sectionnumbers.Get .File.Path) .Title -}}
-                {{- end -}}
-                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a></li>
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{ partial "sectionnumber" . }}{{- $title -}}</a></li>
             {{ end -}}
         </ul>
     {{ else -}}
@@ -45,10 +41,7 @@
             <div class="entry">
                 <h5>
                     {{- $title := .Title -}}
-                    {{- if site.Params.automaticSectionNumbers -}}
-                        {{- $title = printf "%s %s" ($sectionnumbers.Get .File.Path) .Title -}}
-                    {{- end -}}
-                    <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- $title -}}</a>
+                    <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{ partial "sectionnumber" . }}{{- $title -}}</a>
                 </h5>
                 <p>{{ .Description | markdownify -}}</p>
             </div>

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -1,35 +1,3 @@
-{{ if not (in .Site.Params.enabledModule "base") }}
-  {{ warnf "Section numbers do not work correctly unless 'base' is in params.enabledModule" }}
-{{ end }}
-
-{{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
-{{ $data := $navRoot.Scratch }}
-{{/* Check if the current page was already evaluated */}}
-{{ if not ($data.Get .File.Path) }}
-    {{ $data = partialCached "sectionnumber-nested" (dict "page" . "section" $navRoot "data" $data) $navRoot.File.Path }}
-{{ end }}
-{{ return $data }}
-
-{{ define "partials/sectionnumber-nested" -}}
-  {{ $s := .section }}
-  {{ $p := .page }}
-  {{ $d := .data }}
-  {{ $sectionNr := .sectionNr | default "" }}
-  {{ .data.Set $s.File.Path $sectionNr }}
-  {{ $pages := (union $s.Pages $s.Sections).ByWeight -}}
-  {{ $withChild := gt (len $pages) 0 -}}
-  {{- if $withChild }}
-    {{ $count := 0 }}
-    {{ range $pages -}}
-      {{ $onlyWhen := default "base" .Params.onlyWhen }}
-      {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
-        {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
-          {{ $count = add $count 1 }}
-          {{ $newSectionNr := printf "%s%d." $sectionNr $count }}
-          {{ $d = partialCached "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) .File.Path }}
-        {{- end }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{ return $d }}
-{{- end }}
+{{- with .Store.Get "sectionnumber" -}}
+    {{- fmt.Printf "%s " . -}}
+{{- end -}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -40,11 +40,6 @@
 {{ define "section-tree-nav-section" -}}
 {{ $s := .section -}}
 {{ $p := .page -}}
-{{ $sectionnumber := "" }}
-{{ if site.Params.automaticSectionNumbers }}
-  {{ $sectionnumbers := partialCached "sectionnumber.html" .page .page.File.Path }}
-  {{ $sectionnumber = $sectionnumbers.Get .section.File.Path }}
-{{ end }}
 {{ $shouldDelayActive := .shouldDelayActive -}}
 {{ $sidebarMenuTruncate := .sidebarMenuTruncate -}}
 {{ $treeRoot := cond (eq .ulNr 0) true false -}}
@@ -62,9 +57,9 @@
 <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
-  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ with $sectionnumber }}{{ . }} {{ end }}{{ $s.LinkTitle }}</span></a></label>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ partial "sectionnumber" $s }}{{ $s.LinkTitle }}</span></a></label>
   {{ else -}}
-  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ with $sectionnumber }}{{ . }} {{ end }}{{ $s.LinkTitle }}</span></a>
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ partial "sectionnumber" $s }}{{ $s.LinkTitle }}</span></a>
   {{- end }}
   {{- if $withChild }}
   {{- $ulNr := add $ulNr 1 }}

--- a/layouts/pdf/list.html
+++ b/layouts/pdf/list.html
@@ -10,12 +10,7 @@
         {{if and (eq .Type "docs")}}
             <!-- 1st-level pages, e.g. content/en/setup/_index.md and content/en/docs/_index.md -->
             <!-- These pages are the 1st-level in the toc -->
-            {{- if site.Params.automaticSectionNumbers -}}
-                {{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-                <h1 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-weight: bold;">{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</h1>
-            {{- else -}}
-                <h1 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-weight: bold;">{{ .Title }}</h1>
-            {{- end -}}
+            <h1 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-weight: bold;">{{ partial "sectionnumber" . }}{{ .Title }}</h1>
             <!-- dirty hack to have a nice table of contents -->
             <!-- h-tags are simulated by p-tags in order to not appear in the toc -->
             <!-- and the hierarchy of the headers is decremented by one -->
@@ -41,12 +36,7 @@
                     <!-- 2nd-level pages like content/en/docs/01/_index.md -->
                     <!-- but also pages like content/en/docs/concurrency.md -->
                     <!-- These pages are the 2nd-level in the toc -->
-                    {{- if site.Params.automaticSectionNumbers -}}
-                        {{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-                        <h2 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-size: 2em; font-weight: bold;">{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</h2>
-                    {{- else -}}
-                        <h2 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-size: 2em; font-weight: bold;">{{ .Title }}</h2>
-                    {{- end -}}
+                    <h2 class="pdf-break-before" id="{{ substr .RelPermalink 1 -1 }}" style="font-size: 2em; font-weight: bold;">{{ partial "sectionnumber" . }}{{ .Title }}</h2>
                     <!-- dirty hack to have a nice table of contents -->
                     <!-- h-tags are simulated by p-tags in order to not appear in the toc -->
                     <!-- and the hierarchy of the headers is decremented by one, i.e. h3 is now h4 -->
@@ -71,12 +61,7 @@
                         {{ if and (in .Site.Params.enabledModule $onlyWhen) (not (in .Site.Params.enabledModule .Params.onlyWhenNot)) }}
                             <!-- 3rd-level pages like content/en/docs/05/helm.md -->
                             <!-- These pages do not appear in the toc -->
-                            {{- if site.Params.automaticSectionNumbers -}}
-                                {{- $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-                                <p id="{{ substr .RelPermalink 1 -1 }}" style="display: block; font-size: 2em; margin-top: 1em; margin-bottom: 0.6em;margin-left: 0; margin-right: 0; font-weight: bold;">{{ $sectionnumbers.Get .File.Path }} {{ .Title }}</p>
-                            {{- else -}}
-                                <p id="{{ substr .RelPermalink 1 -1 }}" style="display: block; font-size: 2em; margin-top: 1em; margin-bottom: 0.6em;margin-left: 0; margin-right: 0; font-weight: bold;">{{ .Title }}</p>
-                            {{- end -}}
+                            <p id="{{ substr .RelPermalink 1 -1 }}" style="display: block; font-size: 2em; margin-top: 1em; margin-bottom: 0.6em;margin-left: 0; margin-right: 0; font-weight: bold;">{{ partial "sectionnumber" . }}{{ .Title }}</p>
                             <!-- dirty hack to have a nice table of contents -->
                             <!-- h-tags are simulated by p-tags in order to not appear in the toc -->
                             <!-- and the hierarchy of the headers is decremented by two, i.e. h3 is now h5 -->

--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -1,9 +1,5 @@
 {{- $ref := .Get 0 -}}
 {{- $sectionnumber := "" -}}
 {{- with site.GetPage $ref -}}
-{{-   if site.Params.automaticSectionNumbers -}}
-{{-     $sectionnumbers := partialCached "sectionnumber.html" . .File.Path -}}
-{{-     $sectionnumber = $sectionnumbers.Get .File.Path -}}
-{{-   end -}}
-<a href="{{ .Permalink }}">{{ $sectionnumber }} {{ .Title }}</a>
+<a href="{{ .Permalink }}">{{ partial "sectionnumber" .Page }}{{ .Title }}</a>
 {{- end -}}

--- a/layouts/shortcodes/task.html
+++ b/layouts/shortcodes/task.html
@@ -1,11 +1,11 @@
 {{- .Page.Scratch.Add "task" 1 -}}
-{{- if site.Params.automaticSectionNumbers -}}
-{{- $sectionnumbers := partialCached "sectionnumber.html" .Page .Page.File.Path -}}
-Task {{ $sectionnumbers.Get .Page.File.Path }}{{ .Page.Scratch.Get "task" }}:
+{{- if .Page.Store.Get "sectionnumber" -}}
+{{- $sectionnumber := .Page.Store.Get "sectionnumber" -}}
+Task {{ $sectionnumber }}{{ .Page.Scratch.Get "task" }}:
 {{- else -}}
 {{- with .Page.Params.sectionnumber -}}
 Task {{ . }}.{{ $.Page.Scratch.Get "task" }}:
 {{- else -}}
-{{- errorf "Either automaticSectionNumbers or sectionnumber must be set in %q" .Page.Path -}}
+{{- errorf "Either sectionnumber must be set in %q or the sectionnumber page output must be activated" .Page.Path -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This change should make the automatic section numbering easier to understand. 

The usage of `weight` in the output formats is a small hack, so that the template that adds the section numbers to `.Page.Store` is executed before everything else.

This change should be backward compatible if automatic section numbering is not activated. Otherwise the `hugo.toml` must be updated to include the `sectionnumber` output format (see `README`)

The change from `config.toml` to `hugo.toml` in the `README` just follows the current recommendations of Hugo. Both will work just the same. 