### PR TITLE
Allow projects to add custom css

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,3 +1,5 @@
+@import "styles_project_custom";
+
 .alert-info{
  background: #dbe6eb;
 }

--- a/assets/scss/_styles_project_custom.scss
+++ b/assets/scss/_styles_project_custom.scss
@@ -1,0 +1,1 @@
+// Meant for overwriting downstream


### PR DESCRIPTION
Docsy provides a method to add additional project CSS by using the filename `_styles_project.scss`. Since we use this filename in docsy-plus, downstream repositories cannot use it anymore, without overwriting the whole content. To allow custom CSS, this PR adds support for `_styles_project_custom.scss`.

Required by https://github.com/acend/go-basics-training/pull/204