### PR TITLE
don't use deprecated value

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -14,7 +14,7 @@
 {{ if $jsLibs }}
     {{ $jsSite := $jsLibs | resources.Concat "js/site.js" }}
 
-    {{ if not .Site.IsServer }}
+    {{ if not hugo.IsServer }}
       {{ $jsSite = $jsSite | minify }}
     {{ end }}
     {{ $jsSite = $jsSite | fingerprint }}


### PR DESCRIPTION
.Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use hugo.IsServer instead.