### PR TITLE
Fix/endless loop error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/acend/docsy-plus
+module github.com/kreativmonkey/docsy-plus
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kreativmonkey/docsy-plus
+module github.com/acend/docsy-plus
 
 go 1.18
 

--- a/layouts/partials/sectionnumber.html
+++ b/layouts/partials/sectionnumber.html
@@ -26,7 +26,7 @@
         {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
           {{ $count = add $count 1 }}
           {{ $newSectionNr := printf "%s%d." $sectionNr $count }}
-          {{ $d = partialCached "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) .File.Path }}
+          {{ $d = partial "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
On hugo > v0.145 the following error appears:

```
error calling partialCached: template: _partials/sectionnumber.html:29:18: executing "partials/sectionnumber-nested" at <partialCached "sectionnumber-nested" (dict "page" $p "section" . "sectionNr" $newSectionNr "data" $d) .File.Path>: error calling partialCached: circular call stack detected in partial ""
```

this pull request will fix the error.